### PR TITLE
Fix drawing in buffer with different window sizes

### DIFF
--- a/manifold/src/input_window.rs
+++ b/manifold/src/input_window.rs
@@ -119,13 +119,13 @@ impl InputWindow {
 		let delta = mouse_position - window_center;
 		let motion_vector = Line::new(window_center, window_center + (delta * 4.0), 10.0);
 
-		for x in 0..512 {
-			for y in 0..512 {
+		for x in 0..window_size.width {
+			for y in 0..window_size.height {
 				let dist = motion_vector.dist(vec2(x as f32, y as f32));
 				let intensity = dist.map_range(0.5..-0.5, 0.0..1.0).clamp(0.0, 1.0);
 				let intensity_u8 = (intensity * 255.0) as u32;
 				// let intensity_u8 = 255;
-				buffer[(x + (y * 512)) as usize] =
+				buffer[(x + (y * window_size.width)) as usize] =
 					intensity_u8 | (intensity_u8 << 8) | (intensity_u8 << 16);
 			}
 		}


### PR DESCRIPTION
Before:
<img src="https://github.com/StardustXR/non-spatial-input/assets/1484766/0d92b0e2-4cba-49de-ad00-59974f6b56c7" width="300">

After:
<img src="https://github.com/StardustXR/non-spatial-input/assets/1484766/39720e07-3c63-4155-98b4-1701c509e2fd" width="300">